### PR TITLE
PHP 7 compatibility updates

### DIFF
--- a/inc/app/cms/boxes/admintools/uninstalled/index.php
+++ b/inc/app/cms/boxes/admintools/uninstalled/index.php
@@ -1,5 +1,9 @@
 <?php
 
+// As http://www.sitellite.org/apps.xml does not return expected application list
+//	this box is ignored.
+return;
+
 $data = @join ('', @file ('http://www.sitellite.org/apps.xml'));
 if (! $data) {
 	return;

--- a/inc/app/cms/boxes/delete/index.php
+++ b/inc/app/cms/boxes/delete/index.php
@@ -100,7 +100,10 @@ if (! is_array ($parameters['_key'])) {
 		}
 	}
     // index page cannot be deleted 
-	if ((count ($failed) > 0) || (in_array('index',$id))) {
+	if ((count ($failed) > 0) ||
+			(is_array ($id) && in_array ('index', $id)) ||
+			(! is_array ($id) && 'index' === $id))
+	{
 		page_title (intl_get ('An Error Occurred'));
 		echo '<p>' . $rex->error . '</p>';
 		echo '<p>' . intl_get ('The following items were not deleted') . ':</p>';
@@ -124,7 +127,7 @@ echo Workflow::trigger (
 
 session_set ('sitellite_alert', intl_get ('The items have been deleted.'));
 
-if (! empty ($parameters['_return']) && $parameters['_return'] != site_prefix () . '/index/' . $parameters['_key'][0] && ! strpos ($parameters['_return'], $parameters['_key'][0])) {
+if (! empty ($parameters['_return']) && $parameters['_return'] != site_prefix () . '/index/' . $parameters['_key'][0] && ! ('' !== $parameters['_key'][0] && strpos ($parameters['_return'], $parameters['_key'][0]))) {
 	header ('Location: ' . $parameters['_return']);
 	exit;
 }

--- a/inc/app/cms/boxes/services/webhooks/index.php
+++ b/inc/app/cms/boxes/services/webhooks/index.php
@@ -56,7 +56,7 @@ loader_import ('pear.HTTP.Request');
 foreach (explode ("\n", appconf ('cms_webhooks')) as $url) {
 	$url = trim ($url);
 	if (! empty ($url)) {
-		$req =& new HTTP_request ($url);
+		$req = new HTTP_request ($url);
 		$req->setMethod ('POST');
 		$req->addPostData ('event', $parameters['transition']);
 		$req->addPostData ('summary', $parameters['message']);

--- a/inc/app/cms/forms/add/sitellite_filesystem/index.php
+++ b/inc/app/cms/forms/add/sitellite_filesystem/index.php
@@ -116,7 +116,7 @@ class CmsAddSitellite_filesystemForm extends MailForm {
 		$this->widgets['submit_button']->buttons[2]->extra = 'onclick="return cms_cancel (this.form)"';
 	}
 
-	function show () {
+	function show ($template = '') {
 		return loader_box ('cms/user/preferences/level') . parent::show ();
 	}
 

--- a/inc/app/cms/forms/edit/sitellite_filesystem/index.php
+++ b/inc/app/cms/forms/edit/sitellite_filesystem/index.php
@@ -180,7 +180,7 @@ class CmsEditSitellite_filesystemForm extends MailForm {
 		}*/
 	}
 
-	function show () {
+	function show ($template = '') {
 		return loader_box ('cms/user/preferences/level') . parent::show ();
 	}
 

--- a/inc/app/multilingual/boxes/index/index.php
+++ b/inc/app/multilingual/boxes/index/index.php
@@ -104,8 +104,14 @@ if ($cgi->_status == 'untranslated') {
 	foreach ($list as $item) {
 		$parameters['list'][$item->{$r->key}] = $tr->get ($item->{$r->key});
 		if ($parameters['list'][$item->{$r->key}]->collection) {
+			if (! is_object ($parameters['list'][$item->{$r->key}])) {
+				$parameters['list'][$item->{$r->key}] = new stdClass;
+			}
 			$parameters['list'][$item->{$r->key}]->title = multilingual_filter_title ($parameters['list'][$item->{$r->key}]->collection, $item->{$r->key});
 		} else {
+			if (! is_object ($parameters['list'][$item->{$r->key}])) {
+				$parameters['list'][$item->{$r->key}] = new stdClass;
+			}
 			$parameters['list'][$item->{$r->key}]->title = multilingual_filter_title ($cgi->_collection, $item->{$r->key});
 		}
 	}

--- a/inc/app/myadm/docs/fr/001-about-myadm.html
+++ b/inc/app/myadm/docs/fr/001-about-myadm.html
@@ -1,12 +1,12 @@
-<h1>Au sujet Du Gestionnaire De Base de données</h1>
+<h1>Au sujet Du Gestionnaire De Base de donnÃ©es</h1>
 
-<p>Le gestionnaire de base de données est une couche d'accès direct à
-la base de données fondamentale de MySQL sous Sitellite.&nbsp; Il vient
-préinstallé, et est très maniable pour des utilisateurs de puissance et
-les lotisseurs en faisant de bas niveau rapide et sale édite.<br />
+<p>Le gestionnaire de base de donnÃ©es est une couche d'accÃ¨s direct Ã 
+la base de donnÃ©es fondamentale de MySQL sous Sitellite.&nbsp; Il vient
+prÃ©installÃ©, et est trÃ¨s maniable pour des utilisateurs de puissance et
+les lotisseurs en faisant de bas niveau rapide et sale Ã©dite.<br />
 </p>
 <p>La
-partie la plus maniable du gestionnaire de base de données est
-probablement la coquille de SQL, qui vous permet d'exécuter des
-questions arbitraires de SQL contre la base de données, qui est grande
-pour examiner hors du nouveaux code et idées.</p>
+partie la plus maniable du gestionnaire de base de donnÃ©es est
+probablement la coquille de SQL, qui vous permet d'exÃ©cuter des
+questions arbitraires de SQL contre la base de donnÃ©es, qui est grande
+pour examiner hors du nouveaux code et idÃ©es.</p>

--- a/inc/app/myadm/docs/languages.php
+++ b/inc/app/myadm/docs/languages.php
@@ -10,7 +10,7 @@
 
 en                      = English
 
-fr                      = "Français"
+fr                      = "FranÃ§ais"
 
 ;
 ; THE END

--- a/inc/app/siteblog/forms/edit/settings.php
+++ b/inc/app/siteblog/forms/edit/settings.php
@@ -73,7 +73,7 @@ alt         = Category
 [created]
 
 type = calendar
-alt = Posted On
+alt = "Posted On"
 setValue = "eval: date ('Y-m-d H:i:s')"
 nullable		= false
 showsTime		= true

--- a/inc/app/siteconnector/lib/Ext/PEAR/HTTP/docs/download-progress.php
+++ b/inc/app/siteconnector/lib/Ext/PEAR/HTTP/docs/download-progress.php
@@ -78,7 +78,7 @@ class HTTP_Request_DownloadListener extends HTTP_Request_Listener
                 } else {
                     $this->setTarget($this->_target);
                 }
-                $this->_bar =& new Console_ProgressBar(
+                $this->_bar = new Console_ProgressBar(
                     '* ' . $this->_target . ' %fraction% KB [%bar%] %percent%', '=>', '-', 
                     79, (isset($data['content-length'])? round($data['content-length'] / 1024): 100)
                 );
@@ -105,9 +105,9 @@ class HTTP_Request_DownloadListener extends HTTP_Request_Listener
 // to be able to see the progress bar
 $url = 'http://pear.php.net/get/HTML_QuickForm-stable';
 
-$req =& new HTTP_Request($url);
+$req = new HTTP_Request($url);
 
-$download =& new HTTP_Request_DownloadListener();
+$download = new HTTP_Request_DownloadListener();
 $req->attach($download);
 $req->sendRequest(false);
 ?>

--- a/inc/app/siteconnector/lib/Ext/PEAR/SOAP/Base.php
+++ b/inc/app/siteconnector/lib/Ext/PEAR/SOAP/Base.php
@@ -191,7 +191,7 @@ class SOAP_Base_Object extends PEAR
             $fault =& $str;
         } else {
             if (!$code) $code = $is_instance?$this->_myfaultcode:'Client';
-            $fault =& new SOAP_Fault($str,
+            $fault = new SOAP_Fault($str,
                                           $code,
                                           $actorURI,
                                           $detail,
@@ -454,7 +454,7 @@ class SOAP_Base extends SOAP_Base_Object
 
             $array_type = $array_type_prefix = '';
             if ($numtypes != 1) {
-                $arrayTypeQName =& new QName($arrayType);
+                $arrayTypeQName = new QName($arrayType);
                 $arrayType = $arrayTypeQName->name;
                 $array_types = array();
                 $array_val = NULL;
@@ -540,8 +540,8 @@ class SOAP_Base extends SOAP_Base_Object
         $xml_attr = '';
         if (count($attributes) > 0) {
             foreach ($attributes as $k => $v) {
-                $kqn =& new QName($k);
-                $vqn =& new QName($v);
+                $kqn = new QName($k);
+                $vqn = new QName($v);
                 $xml_attr .= ' '.$kqn->fqn().'="'.$vqn->fqn().'"';
             }
         }
@@ -637,7 +637,7 @@ class SOAP_Base extends SOAP_Base_Object
                 if ($this->_isBase64($value)) {
                     $type = 'base64Binary';
                 } else {
-                    $dt =& new SOAP_Type_dateTime($value);
+                    $dt = new SOAP_Type_dateTime($value);
                     if ($dt->toUnixtime() != -1) {
                         $type = 'dateTime';
                         #$value = $dt->toSOAP();
@@ -751,7 +751,7 @@ class SOAP_Base extends SOAP_Base_Object
                         if ($t && class_exists($t)) $classname = $t;
                     }
                 }
-                $return =& new $classname;
+                $return = new $classname;
             } else {
                 $return = array();
             }
@@ -893,7 +893,7 @@ class SOAP_Base extends SOAP_Base_Object
         // see http://www.w3.org/TR/SOAP-attachments
         // now we have to mime encode the message
         $params = array('content_type' => 'multipart/related; type=text/xml');
-        $msg =& new Mail_mimePart('', $params);
+        $msg = new Mail_mimePart('', $params);
         // add the xml part
         $params['content_type'] = 'text/xml';
         $params['charset'] = $encoding;
@@ -921,7 +921,7 @@ class SOAP_Base extends SOAP_Base_Object
         // encode any attachments
         // see http://search.ietf.org/internet-drafts/draft-nielsen-dime-soap-00.txt
         // now we have to DIME encode the message
-        $dime =& new Net_DIME_Message();
+        $dime = new Net_DIME_Message();
         $msg =& $dime->encodeData($xml,SOAP_ENVELOP,NULL,NET_DIME_TYPE_URI);
 
         // add the attachements
@@ -947,7 +947,7 @@ class SOAP_Base extends SOAP_Base_Object
         $params['decode_headers'] = TRUE;
 
         // XXX lame thing to have to do for decoding
-        $decoder =& new Mail_mimeDecode($data);
+        $decoder = new Mail_mimeDecode($data);
         $structure = $decoder->decode($params);
 
         if (isset($structure->body)) {
@@ -989,7 +989,7 @@ class SOAP_Base extends SOAP_Base_Object
 
         // XXX this SHOULD be moved to the transport layer, e.g. PHP  itself
         // should handle parsing DIME ;)
-        $dime =& new Net_DIME_Message();
+        $dime = new Net_DIME_Message();
         $err = $dime->decodeData($data);
         if ( PEAR::isError($err) ) {
             $this->_raiseSoapFault('Failed to decode the DIME message!','','','Server');
@@ -1013,7 +1013,7 @@ class SOAP_Base extends SOAP_Base_Object
 
     function __set_type_translation($type, $class=NULL)
     {
-        $tq =& new QName($type);
+        $tq = new QName($type);
         if (!$class) {
             $class = $tq->name;
         }

--- a/inc/app/siteconnector/lib/Ext/PEAR/SOAP/Client.php
+++ b/inc/app/siteconnector/lib/Ext/PEAR/SOAP/Client.php
@@ -146,7 +146,7 @@ class SOAP_Client extends SOAP_Base
         if ($wsdl) {
             $this->__endpointType = 'wsdl';
             // instantiate wsdl class
-            $this->_wsdl =& new SOAP_WSDL($this->_endpoint, $this->__proxy_params);
+            $this->_wsdl = new SOAP_WSDL($this->_endpoint, $this->__proxy_params);
             if ($this->_wsdl->fault) {
                 $this->_raiseSoapFault($this->_wsdl->fault);
             }
@@ -197,7 +197,7 @@ class SOAP_Client extends SOAP_Base
             $this->headersOut[] =& $soap_value;
         } else if (gettype($soap_value) == 'array') {
             // name, value, namespace, mustunderstand, actor
-            $this->headersOut[] =& new SOAP_Header($soap_value[0], NULL, $soap_value[1], $soap_value[2], $soap_value[3]);;
+            $this->headersOut[] = new SOAP_Header($soap_value[0], NULL, $soap_value[1], $soap_value[2], $soap_value[3]);;
         } else {
             $this->_raiseSoapFault("Don't understand the header info you provided.  Must be array or SOAP_Header.");
         }
@@ -434,7 +434,7 @@ class SOAP_Client extends SOAP_Base
                     if (gettype($nparams[$name]) != 'object' ||
                         !is_a($nparams[$name],'soap_value')) {
                         // type is a qname likely, split it apart, and get the type namespace from wsdl
-                        $qname =& new QName($part['type']);
+                        $qname = new QName($part['type']);
                         if ($qname->ns)
                             $type_namespace = $this->_wsdl->namespaces[$qname->ns];
                         else if (isset($part['namespace']))
@@ -445,7 +445,7 @@ class SOAP_Client extends SOAP_Base
                         $type = $qname->name;
                         $pqname = $name;
                         if ($xmlns) $pqname = '{'.$xmlns.'}'.$name;
-                        $nparams[$name] =& new SOAP_Value($pqname, $qname->fqn(), $nparams[$name],$attrs);
+                        $nparams[$name] = new SOAP_Value($pqname, $qname->fqn(), $nparams[$name],$attrs);
                     } else {
                         // wsdl fixups to the soap value
                     }
@@ -465,21 +465,21 @@ class SOAP_Client extends SOAP_Base
         if (!isset($this->__options['style']) || $this->__options['style'] == 'rpc') {
             $this->__options['style'] = 'rpc';
             $this->docparams = true;
-            $mqname =& new QName($method, $namespace);
-            $methodValue =& new SOAP_Value($mqname->fqn(), 'Struct', $params);
+            $mqname = new QName($method, $namespace);
+            $methodValue = new SOAP_Value($mqname->fqn(), 'Struct', $params);
             $soap_msg =& $this->_makeEnvelope($methodValue, $this->headersOut, $this->_encoding,$this->__options);
         } else {
             if (!$params) {
-                $mqname =& new QName($method, $namespace);
+                $mqname = new QName($method, $namespace);
                 $mynull = NULL;
-                $params =& new SOAP_Value($mqname->fqn(), 'Struct', $mynull);
+                $params = new SOAP_Value($mqname->fqn(), 'Struct', $mynull);
             } elseif ($this->__options['input'] == 'parse') {
                 if (is_array($params)) {
                     $nparams = array();
                     $keys = array_keys($params);
                     foreach ($keys as $k) {
                         if (gettype($params[$k]) != 'object') {
-                            $nparams[] =& new SOAP_Value($k, false, $params[$k]);
+                            $nparams[] = new SOAP_Value($k, false, $params[$k]);
                         } else {
                             $nparams[] =& $params[$k];
                         }
@@ -487,8 +487,8 @@ class SOAP_Client extends SOAP_Base
                     $params =& $nparams;
                 }
                 if ($this->__options['parameters']) {
-                    $mqname =& new QName($method, $namespace);
-                    $params =& new SOAP_Value($mqname->fqn(), 'Struct', $params);
+                    $mqname = new QName($method, $namespace);
+                    $params = new SOAP_Value($mqname->fqn(), 'Struct', $params);
                 }
             }
             $soap_msg =& $this->_makeEnvelope($params, $this->headersOut, $this->_encoding,$this->__options);
@@ -534,7 +534,7 @@ class SOAP_Client extends SOAP_Base
     function &__parse(&$response, $encoding, &$attachments)
     {
         // parse the response
-        $response =& new SOAP_Parser($response, $encoding, $attachments);
+        $response = new SOAP_Parser($response, $encoding, $attachments);
         if ($response->fault) {
             return $this->_raiseSoapFault($response->fault);
         }

--- a/inc/app/siteconnector/lib/Ext/PEAR/SOAP/Fault.php
+++ b/inc/app/siteconnector/lib/Ext/PEAR/SOAP/Fault.php
@@ -60,18 +60,18 @@ class SOAP_Fault extends PEAR_Error
      */
     function message()
     {
-        $msg =& new SOAP_Base();
+        $msg = new SOAP_Base();
         $params = array();
-        $params[] =& new SOAP_Value('faultcode', 'QName', 'SOAP-ENV:'.$this->code);
-        $params[] =& new SOAP_Value('faultstring', 'string', $this->message);
-        $params[] =& new SOAP_Value('faultactor', 'anyURI', $this->error_message_prefix);
+        $params[] = new SOAP_Value('faultcode', 'QName', 'SOAP-ENV:'.$this->code);
+        $params[] = new SOAP_Value('faultstring', 'string', $this->message);
+        $params[] = new SOAP_Value('faultactor', 'anyURI', $this->error_message_prefix);
         if (isset($this->backtrace)) {
-            $params[] =& new SOAP_Value('detail', 'string', $this->backtrace);
+            $params[] = new SOAP_Value('detail', 'string', $this->backtrace);
         } else {
-            $params[] =& new SOAP_Value('detail', 'string', $this->userinfo);
+            $params[] = new SOAP_Value('detail', 'string', $this->userinfo);
         }
         
-        $methodValue =& new SOAP_Value('{'.SOAP_ENVELOP.'}Fault', 'Struct', $params);
+        $methodValue = new SOAP_Value('{'.SOAP_ENVELOP.'}Fault', 'Struct', $params);
         $headers = NULL;
         return $msg->_makeEnvelope($methodValue, $headers);
     }
@@ -88,7 +88,7 @@ class SOAP_Fault extends PEAR_Error
     {
         global $SOAP_OBJECT_STRUCT;
         if ($SOAP_OBJECT_STRUCT) {
-            $fault =& new stdClass();
+            $fault = new stdClass();
             $fault->faultcode = $this->code;
             $fault->faultstring = $this->message;
             $fault->faultactor = $this->error_message_prefix;

--- a/inc/app/siteconnector/lib/Ext/PEAR/SOAP/Parser.php
+++ b/inc/app/siteconnector/lib/Ext/PEAR/SOAP/Parser.php
@@ -182,14 +182,14 @@ class SOAP_Parser extends SOAP_Base
         }
         // add current node's value
         if ($response) {
-            $nqn =& new Qname($this->message[$pos]['name'],$this->message[$pos]['namespace']);
-            $tqn =& new Qname($this->message[$pos]['type'],$this->message[$pos]['type_namespace']);
-            $response =& new SOAP_Value($nqn->fqn(), $tqn->fqn(), $response, $attrs);
+            $nqn = new Qname($this->message[$pos]['name'],$this->message[$pos]['namespace']);
+            $tqn = new Qname($this->message[$pos]['type'],$this->message[$pos]['type_namespace']);
+            $response = new SOAP_Value($nqn->fqn(), $tqn->fqn(), $response, $attrs);
             if (isset($this->message[$pos]['arrayType'])) $response->arrayType = $this->message[$pos]['arrayType'];
         } else {
-            $nqn =& new Qname($this->message[$pos]['name'],$this->message[$pos]['namespace']);
-            $tqn =& new Qname($this->message[$pos]['type'],$this->message[$pos]['type_namespace']);
-            $response =& new SOAP_Value($nqn->fqn(), $tqn->fqn(), $this->message[$pos]['cdata'], $attrs);
+            $nqn = new Qname($this->message[$pos]['name'],$this->message[$pos]['namespace']);
+            $tqn = new Qname($this->message[$pos]['type'],$this->message[$pos]['type_namespace']);
+            $response = new SOAP_Value($nqn->fqn(), $tqn->fqn(), $this->message[$pos]['cdata'], $attrs);
         }
         // handle header attribute that we need
         if (array_key_exists('actor',$this->message[$pos])) {
@@ -242,7 +242,7 @@ class SOAP_Parser extends SOAP_Base
         $this->depth_array[$this->depth] = $pos;
         // set self as current parent
         $this->parent = $pos;
-        $qname =& new QName($name);
+        $qname = new QName($name);
         // set status
         if (strcasecmp('envelope',$qname->name)==0) {
             $this->status = 'envelope';
@@ -287,7 +287,7 @@ class SOAP_Parser extends SOAP_Base
         // loop through atts, logging ns and type declarations
         foreach ($attrs as $key => $value) {
             // if ns declarations, add to class level array of valid namespaces
-            $kqn =& new QName($key);
+            $kqn = new QName($key);
             if ($kqn->ns == 'xmlns') {
                 $prefix = $kqn->name;
 
@@ -312,14 +312,14 @@ class SOAP_Parser extends SOAP_Base
                 
             // if it's a type declaration, set type
             } elseif ($kqn->name == 'type') {
-                $vqn =& new QName($value);
+                $vqn = new QName($value);
                 $this->message[$pos]['type'] = $vqn->name;
                 $this->message[$pos]['type_namespace'] = $this->_getNamespaceForPrefix($vqn->ns);
                 #print "set type for {$this->message[$pos]['name']} to {$this->message[$pos]['type']}\n";
                 // should do something here with the namespace of specified type?
                 
             } elseif ($kqn->name == 'arrayType') {
-                $vqn =& new QName($value);
+                $vqn = new QName($value);
                 $this->message[$pos]['type'] = 'Array';
                 #$type = $vqn->name;
                 if (isset($vqn->arraySize))
@@ -385,7 +385,7 @@ class SOAP_Parser extends SOAP_Base
         $pos = $this->depth_array[$this->depth];
         // bring depth down a notch
         $this->depth--;
-        $qname =& new QName($name);
+        $qname = new QName($name);
         
         // get type if not explicitly declared in an xsi:type attribute
         // XXX check on integrating wsdl validation here

--- a/inc/app/siteconnector/lib/Ext/PEAR/SOAP/Server.php
+++ b/inc/app/siteconnector/lib/Ext/PEAR/SOAP/Server.php
@@ -271,8 +271,8 @@ class SOAP_Server extends SOAP_Base
                     if (is_a($method_response[$i],'soap_value')) {
                         $return_val[] = $method_response[$i++];
                     } else {
-                        $qn =& new QName($key, $namespace);
-                        $return_val[] =& new SOAP_Value($qn->fqn(),$type,$method_response[$i++]);
+                        $qn = new QName($key, $namespace);
+                        $return_val[] = new SOAP_Value($qn->fqn(),$type,$method_response[$i++]);
                     }
                 }
             } else {
@@ -282,9 +282,9 @@ class SOAP_Server extends SOAP_Base
                     $values = array_values($return_type);
                     $return_type = $values[0];
                 }
-                $qn =& new QName($return_name, $namespace);
+                $qn = new QName($return_name, $namespace);
                 $return_val = array();
-                $return_val[] =& new SOAP_Value($qn->fqn(),$return_type,$method_response);
+                $return_val[] = new SOAP_Value($qn->fqn(),$return_type,$method_response);
             }
         }
         return $return_val;
@@ -293,7 +293,7 @@ class SOAP_Server extends SOAP_Base
     function parseRequest($data = '', $attachments = null)
     {
         // parse response, get soap parser obj
-        $parser =& new SOAP_Parser($data,$this->xml_encoding,$attachments);
+        $parser = new SOAP_Parser($data,$this->xml_encoding,$attachments);
         // if fault occurred during message parsing
         if ($parser->fault) {
             $this->fault = $parser->fault;
@@ -415,8 +415,8 @@ class SOAP_Server extends SOAP_Base
             else
                 $return_val = $this->buildResult($method_response, $this->return_type);
 
-            $qn =& new QName($this->methodname.'Response',$this->method_namespace);
-            $methodValue =& new SOAP_Value($qn->fqn(), 'Struct', $return_val);
+            $qn = new QName($this->methodname.'Response',$this->method_namespace);
+            $methodValue = new SOAP_Value($qn->fqn(), 'Struct', $return_val);
         } else {
             $methodValue =& $method_response;
         }
@@ -668,7 +668,7 @@ class SOAP_Server extends SOAP_Base
      */
     function bindWSDL($wsdl_url) {
         // instantiate wsdl class
-        $this->_wsdl =& new SOAP_WSDL($wsdl_url);
+        $this->_wsdl = new SOAP_WSDL($wsdl_url);
         if ($this->_wsdl->fault) {
             $this->_raiseSoapFault($this->_wsdl->fault);
         }
@@ -679,7 +679,7 @@ class SOAP_Server extends SOAP_Base
      */
     function addObjectWSDL(&$wsdl_obj, $targetNamespace, $service_name, $service_desc = '') {
         if (!isset($this->_wsdl)) {
-            $this->_wsdl =& new SOAP_WSDL;
+            $this->_wsdl = new SOAP_WSDL;
         }
 
         $this->_wsdl->parseObject($wsdl_obj, $targetNamespace, $service_name, $service_desc);

--- a/inc/app/siteconnector/lib/Ext/PEAR/SOAP/Server/Email.php
+++ b/inc/app/siteconnector/lib/Ext/PEAR/SOAP/Server/Email.php
@@ -124,7 +124,7 @@ class SOAP_Server_Email extends SOAP_Server {
         if ($this->soapfault) {
             return $this->soapfault->getFault();
         }
-        $client =& new SOAP_Client(NULL);
+        $client = new SOAP_Client(NULL);
         return $client->__parse($data, $this->xml_encoding, $this->attachments);
     }
     

--- a/inc/app/siteconnector/lib/Ext/PEAR/SOAP/Transport/SMTP.php
+++ b/inc/app/siteconnector/lib/Ext/PEAR/SOAP/Transport/SMTP.php
@@ -150,20 +150,20 @@ class SOAP_Transport_SMTP extends SOAP_Base
             'password' => $this->password,
             'auth' => $this->auth
         );
-        $mailer =& new Mail_smtp($mailer_params);
+        $mailer = new Mail_smtp($mailer_params);
         $result = $mailer->send($this->urlparts['path'], $headers, $out);
         #$result = mail($this->urlparts['path'], $headers['Subject'], $out, $header_text);
 
         if (!PEAR::isError($result)) {
-            $val =& new SOAP_Value('Message-ID','string',$headers['Message-ID']);
+            $val = new SOAP_Value('Message-ID','string',$headers['Message-ID']);
         } else {
-            $sval[] =& new SOAP_Value('faultcode','QName','SOAP-ENV:Client');
-            $sval[] =& new SOAP_Value('faultstring','string',"couldn't send SMTP message to {$this->urlparts['path']}");
-            $val =& new SOAP_Value('Fault','Struct',$sval);
+            $sval[] = new SOAP_Value('faultcode','QName','SOAP-ENV:Client');
+            $sval[] = new SOAP_Value('faultstring','string',"couldn't send SMTP message to {$this->urlparts['path']}");
+            $val = new SOAP_Value('Fault','Struct',$sval);
         }
 
-        $mqname =& new QName($method, $namespace);
-        $methodValue =& new SOAP_Value('Response', 'Struct', array($val));
+        $mqname = new QName($method, $namespace);
+        $methodValue = new SOAP_Value('Response', 'Struct', array($val));
 
         $this->incoming_payload =& $this->_makeEnvelope($methodValue, $this->headers, $this->encoding);
 

--- a/inc/app/siteconnector/lib/Ext/PEAR/SOAP/Value.php
+++ b/inc/app/siteconnector/lib/Ext/PEAR/SOAP/Value.php
@@ -84,10 +84,10 @@ class SOAP_Value
     function SOAP_Value($name = '', $type = false, $value=NULL, $attributes = array())
     {
         // detect type if not passed
-        $this->nqn =& new QName($name);
+        $this->nqn = new QName($name);
         $this->name = $this->nqn->name;
         $this->namespace = $this->nqn->namespace;
-        $this->tqn =& new QName($type);
+        $this->tqn = new QName($type);
         $this->type = $this->tqn->name;
         $this->type_prefix = $this->tqn->ns;
         $this->type_namespace = $this->tqn->namespace;

--- a/inc/app/siteconnector/lib/Ext/PEAR/SOAP/WSDL.php
+++ b/inc/app/siteconnector/lib/Ext/PEAR/SOAP/WSDL.php
@@ -129,7 +129,7 @@ class SOAP_WSDL extends SOAP_Base
      * @return void
      */
     function parseURL($wsdl_uri, $proxy = array()) {
-        $parser =& new SOAP_WSDL_Parser($wsdl_uri, $this);
+        $parser = new SOAP_WSDL_Parser($wsdl_uri, $this);
 
         if ($parser->fault) {
             $this->_raiseSoapFault($parser->fault);
@@ -146,7 +146,7 @@ class SOAP_WSDL extends SOAP_Base
      */
     function parseObject(&$wsdl_obj, $targetNamespace, $service_name, $service_desc = '')
     {
-        $parser =& new SOAP_WSDL_ObjectParser($wsdl_obj, $this, $targetNamespace, $service_name, $service_desc);
+        $parser = new SOAP_WSDL_ObjectParser($wsdl_obj, $this, $targetNamespace, $service_name, $service_desc);
 
          if ($parser->fault) {
              $this->_raiseSoapFault($parser->fault);
@@ -391,7 +391,7 @@ class SOAP_WSDL extends SOAP_Base
                 $comments .= "        // {$el['type']} may require attributes, refer to wsdl for more info\n";
             }
             $comments .= "        \${$attrname}['xmlns'] = '{$this->namespaces[$_argtype['namespace']]}';\n";
-            $comments .= "        \${$_argtype['type']} =& new SOAP_Value('{$_argtype['type']}',false,\${$_argtype['type']},\$$attrname);\n";
+            $comments .= "        \${$_argtype['type']} = new SOAP_Value('{$_argtype['type']}',false,\${$_argtype['type']},\$$attrname);\n";
             $this->_addArg($args,$argarray,$_argtype['type']);
             if (isset($this->complexTypes[$tns][$el['type']]['attribute'])) {
                 if ($args) $args .= ", ";
@@ -400,12 +400,12 @@ class SOAP_WSDL extends SOAP_Base
             #$comments = $this->_complexTypeArg($args,$argarray,$el,$_argtype['type']);
         } else if (isset($el['elements'])) {
             foreach ($el['elements'] as $ename => $element) {
-                $comments .= "        \$$ename =& new SOAP_Value('{{$this->namespaces[$element['namespace']]}}$ename','{$element['type']}',\$$ename);\n";
+                $comments .= "        \$$ename = new SOAP_Value('{{$this->namespaces[$element['namespace']]}}$ename','{$element['type']}',\$$ename);\n";
                 $this->_addArg($args,$argarray,$ename);
             }
         } else {
-            #$echoStringParam =& new SOAP_Value('{http://soapinterop.org/xsd}echoStringParam',false,$echoStringParam);
-            $comments .= "        \$$_argname =& new SOAP_Value('{{$this->namespaces[$tns]}}$_argname','{$el['type']}',\$$_argname);\n";
+            #$echoStringParam = new SOAP_Value('{http://soapinterop.org/xsd}echoStringParam',false,$echoStringParam);
+            $comments .= "        \$$_argname = new SOAP_Value('{{$this->namespaces[$tns]}}$_argname','{$el['type']}',\$$_argname);\n";
             $this->_addArg($args,$argarray,$_argname);
         }
         return $comments;
@@ -421,7 +421,7 @@ class SOAP_WSDL extends SOAP_Base
                 $comments .= "        // $_argname may require attributes, refer to wsdl for more info\n";
             }
             $wrapname = '{'.$this->namespaces[$_argtype['namespace']].'}'.$_argtype['type'];
-            $comments .= "        \$$_argname =& new SOAP_Value('$_argname','$wrapname',\$$_argname);\n";
+            $comments .= "        \$$_argname = new SOAP_Value('$_argname','$wrapname',\$$_argname);\n";
 
         }
         $this->_addArg($args,$argarray,$_argname);
@@ -538,7 +538,7 @@ class SOAP_WSDL extends SOAP_Base
                                 }*/
                                 if($el['complex'] && $argarray) {
                                     $wrapname = '{'.$this->namespaces[$_argtype['namespace']].'}'.$el['name'];
-                                    $comments .= "        \${$el['name']} =& new SOAP_Value('$wrapname',false,\$v=array($argarray));\n";
+                                    $comments .= "        \${$el['name']} = new SOAP_Value('$wrapname',false,\$v=array($argarray));\n";
                                     $argarray = "'{$el['name']}'=>\${$el['name']}";
                                 }
                         } else
@@ -849,7 +849,7 @@ class SOAP_WSDL_Cache extends SOAP_Base
                 }
             } else {
                 $uri = explode('?',$wsdl_fname);
-                $rq =& new HTTP_Request($uri[0], $proxy_params);
+                $rq = new HTTP_Request($uri[0], $proxy_params);
                 // the user agent HTTP_Request uses fouls things up
                 if (isset($uri[1])) {
                     $rq->addRawQueryString($uri[1]);
@@ -916,7 +916,7 @@ class SOAP_WSDL_Parser extends SOAP_Base
     // constructor
     function SOAP_WSDL_Parser($uri, &$wsdl, $docs = false) {
         parent::SOAP_Base('WSDLPARSER');
-        $this->cache =& new SOAP_WSDL_Cache($wsdl->cacheUse, $wsdl->cacheMaxAge);
+        $this->cache = new SOAP_WSDL_Cache($wsdl->cacheUse, $wsdl->cacheMaxAge);
         $this->uri = $uri;
         $this->wsdl = &$wsdl;
         $this->docs = $docs;
@@ -953,7 +953,7 @@ class SOAP_WSDL_Parser extends SOAP_Base
     // start-element handler
     function startElement($parser, $name, $attrs) {
         // get element prefix
-        $qname =& new QName($name);
+        $qname = new QName($name);
         if ($qname->ns) {
             $ns = $qname->ns;
             if ($ns && ((!$this->tns && strcasecmp($qname->name,'definitions') == 0) || $ns == $this->tns)) {
@@ -998,7 +998,7 @@ class SOAP_WSDL_Parser extends SOAP_Base
                     if (!isset($attrs['namespace'])) $attrs['namespace'] = $this->schema;
                     $this->wsdl->complexTypes[$this->schema][$this->currentComplexType] = $attrs;
                     if (array_key_exists('base',$attrs)) {
-                        $qn =& new QName($attrs['base']);
+                        $qn = new QName($attrs['base']);
                         $this->wsdl->complexTypes[$this->schema][$this->currentComplexType]['type'] = $qn->name;
                         $this->wsdl->complexTypes[$this->schema][$this->currentComplexType]['namespace'] = $qn->ns;
                     } else {
@@ -1011,7 +1011,7 @@ class SOAP_WSDL_Parser extends SOAP_Base
             break;
             case 'element':
                 if (isset($attrs['type'])) {
-                    $qn =& new QName($attrs['type']);
+                    $qn = new QName($attrs['type']);
                     $attrs['type'] = $qn->name;
                     #$this->wsdl->getNamespaceAttributeName
                     if ($qn->ns && array_key_exists($qn->ns, $this->wsdl->namespaces)) {
@@ -1056,7 +1056,7 @@ class SOAP_WSDL_Parser extends SOAP_Base
             case 'restriction':
                 if ($this->schemaStatus == 'complexType') {
                     if ($attrs['base']) {
-                        $qn =& new QName($attrs['base']);
+                        $qn = new QName($attrs['base']);
                         $this->wsdl->complexTypes[$this->schema][$this->currentComplexType]['type'] = $qn->name;
                         $this->wsdl->complexTypes[$this->schema][$this->currentComplexType]['namespace'] = $qn->ns;
                     } else {
@@ -1089,10 +1089,10 @@ class SOAP_WSDL_Parser extends SOAP_Base
                         $this->wsdl->complexTypes[$this->schema][$this->currentComplexType]['attribute'][$attrs['name']] = $attrs;
                     } else
                     if (isset($attrs['ref'])) {
-                        $q =& new QName($attrs['ref']);
+                        $q = new QName($attrs['ref']);
                         foreach ($attrs as $k => $v) {
                             if ($k != 'ref' && strstr($k, $q->name)) {
-                                $vq =& new QName($v);
+                                $vq = new QName($v);
                                 if ($q->name == 'arrayType') {
                                     $this->wsdl->complexTypes[$this->schema][$this->currentComplexType][$q->name] = $vq->name.$vq->arrayInfo;
                                     $this->wsdl->complexTypes[$this->schema][$this->currentComplexType]['type'] = 'Array';
@@ -1116,9 +1116,9 @@ class SOAP_WSDL_Parser extends SOAP_Base
             case 'part':
                 $qn = NULL;
                 if (isset($attrs['type'])) {
-                    $qn =& new QName($attrs['type']);
+                    $qn = new QName($attrs['type']);
                 } else if (isset($attrs['element'])) {
-                    $qn =& new QName($attrs['element']);
+                    $qn = new QName($attrs['element']);
                 }
                 if ($qn) {
                     $attrs['type'] = $qn->name;
@@ -1154,7 +1154,7 @@ class SOAP_WSDL_Parser extends SOAP_Base
                         $this->wsdl->portTypes[$this->currentPortType][$this->currentOperation][$name] = $attrs;
                     }
                     if (array_key_exists('message',$attrs)) {
-                        $qn =& new QName($attrs['message']);
+                        $qn = new QName($attrs['message']);
                         $this->wsdl->portTypes[$this->currentPortType][$this->currentOperation][$name]['message'] = $qn->name;
                         $this->wsdl->portTypes[$this->currentPortType][$this->currentOperation][$name]['namespace'] = $qn->ns;
                     }
@@ -1330,7 +1330,7 @@ class SOAP_WSDL_Parser extends SOAP_Base
                 $this->currentPort = $attrs['name'];
                 $this->wsdl->services[$this->currentService]['ports'][$this->currentPort] = $attrs;
                 // XXX hack to deal with binding namespaces
-                $qn =& new QName($attrs['binding']);
+                $qn = new QName($attrs['binding']);
                 $this->wsdl->services[$this->currentService]['ports'][$this->currentPort]['binding'] = $qn->name;
                 $this->wsdl->services[$this->currentService]['ports'][$this->currentPort]['namespace'] = $qn->ns;
             break;
@@ -1371,7 +1371,7 @@ class SOAP_WSDL_Parser extends SOAP_Base
                     $base = parse_url($this->uri);
                     $uri = $this->merge_url($base,$uri);
                 }
-                $import_parser =& new SOAP_WSDL_Parser($uri, $this->wsdl);
+                $import_parser = new SOAP_WSDL_Parser($uri, $this->wsdl);
                 if ($import_parser->fault) {
                     return FALSE;
                 }
@@ -1405,7 +1405,7 @@ class SOAP_WSDL_Parser extends SOAP_Base
             if ($qname->ns && $qname->ns != $this->tns) break;
             $this->status = 'binding';
             $this->currentBinding = $attrs['name'];
-            $qn =& new QName($attrs['type']);
+            $qn = new QName($attrs['type']);
             $this->wsdl->bindings[$this->currentBinding]['type'] = $qn->name;
             $this->wsdl->bindings[$this->currentBinding]['namespace'] = $qn->ns;
         break;
@@ -1423,7 +1423,7 @@ class SOAP_WSDL_Parser extends SOAP_Base
             $this->wsdl->definition = $attrs;
             foreach ($attrs as $key => $value) {
                 if (strstr($key,'xmlns:') !== FALSE) {
-                    $qn =& new QName($key);
+                    $qn = new QName($key);
                     // XXX need to refactor ns handling
                     $this->wsdl->namespaces[$qn->name] = $value;
                     $this->wsdl->ns[$value] = $qn->name;

--- a/inc/app/siteconnector/lib/Ext/PEAR/SOAP/example/email_pop_gateway.php
+++ b/inc/app/siteconnector/lib/Ext/PEAR/SOAP/example/email_pop_gateway.php
@@ -43,7 +43,7 @@ $server->addObjectMap($soapclass,'urn:SOAP_Example_Server');
 
 /* Connect to a POP3 server and read the messages */
 
-$pop3 =& new Net_POP3();
+$pop3 = new Net_POP3();
 if ($pop3->connect('localhost', 110)) {
     if ($pop3->login('username', 'password')) {
         $listing = $pop3->getListing();

--- a/inc/app/siteconnector/lib/Ext/PEAR/SOAP/example/email_pop_server.php
+++ b/inc/app/siteconnector/lib/Ext/PEAR/SOAP/example/email_pop_server.php
@@ -43,7 +43,7 @@ $server->addObjectMap($soapclass,'urn:SOAP_Example_Server');
 
 /* Connect to a POP3 server and read the messages */
 
-$pop3 =& new Net_POP3();
+$pop3 = new Net_POP3();
 if ($pop3->connect('localhost', 110)) {
     if ($pop3->login('username', 'password')) {
         $listing = $pop3->getListing();

--- a/inc/app/siteconnector/lib/Ext/PEAR/SOAP/example/example_types.php
+++ b/inc/app/siteconnector/lib/Ext/PEAR/SOAP/example/example_types.php
@@ -25,9 +25,9 @@ class SOAPStruct {
     
     function &__to_soap($name = 'inputStruct', $header=false, $mustUnderstand=0, $actor='http://schemas.xmlsoap.org/soap/actor/next')
     {
-        $inner[] =& new SOAP_Value('varString','string',$this->varString);
-        $inner[] =& new SOAP_Value('varInt','int',$this->varInt);
-        $inner[] =& new SOAP_Value('varFloat','float',$this->varFloat);
+        $inner[] = new SOAP_Value('varString','string',$this->varString);
+        $inner[] = new SOAP_Value('varInt','int',$this->varInt);
+        $inner[] = new SOAP_Value('varFloat','float',$this->varFloat);
         if ($header) {
             return new SOAP_Header($name,'{http://soapinterop.org/xsd}SOAPStruct',$inner,$mustUnderstand,$actor);
         }

--- a/inc/app/siteconnector/lib/Ext/PEAR/SOAP/tools/genproxy.php
+++ b/inc/app/siteconnector/lib/Ext/PEAR/SOAP/tools/genproxy.php
@@ -12,7 +12,7 @@ require_once 'SOAP/WSDL.php';
  */
 
 function do_wsdl($uri) {
-    $wsdl =& new SOAP_WSDL($uri);
+    $wsdl = new SOAP_WSDL($uri);
     print $wsdl->generateAllProxies();
 }
 echo "<?php\n\nrequire_once 'SOAP/Client.php';\n\n";

--- a/inc/app/siteconnector/lib/Ext/PEAR/XML/HTMLSax/docs/examples/ExpatvsHtmlSax.php
+++ b/inc/app/siteconnector/lib/Ext/PEAR/XML/HTMLSax/docs/examples/ExpatvsHtmlSax.php
@@ -20,7 +20,7 @@ class MyHandler {
     function closeHandler(& $parser,$name) {}
     function dataHandler(& $parser,$data) {}
 }
-$handler=& new MyHandler();
+$handler= new MyHandler();
 
 
 $parser = xml_parser_create();
@@ -36,7 +36,7 @@ $end = getmicrotime();
 echo ( "Expat took:\t\t".(getmicrotime()-$start)."<br />" );
 
 $start = getmicrotime();
-$parser =& new XML_HTMLSax();
+$parser = new XML_HTMLSax();
 $parser->set_object($handler);
 $parser->set_element_handler('openHandler','closeHandler');
 $parser->set_data_handler('dataHandler');

--- a/inc/app/siteconnector/lib/Ext/PEAR/XML/HTMLSax/docs/examples/HTMLtoXHTML.php
+++ b/inc/app/siteconnector/lib/Ext/PEAR/XML/HTMLSax/docs/examples/HTMLtoXHTML.php
@@ -97,10 +97,10 @@ class HTMLtoXHTMLHandler {
 $doc=file_get_contents('example.html');
 
 // Instantiate the handler
-$handler=& new HTMLtoXHTMLHandler();
+$handler= new HTMLtoXHTMLHandler();
 
 // Instantiate the parser
-$parser=& new XML_HTMLSax();
+$parser= new XML_HTMLSax();
 
 // Register the handler with the parser
 $parser->set_object($handler);

--- a/inc/app/siteconnector/lib/Ext/PEAR/XML/HTMLSax/docs/examples/SimpleExample.php
+++ b/inc/app/siteconnector/lib/Ext/PEAR/XML/HTMLSax/docs/examples/SimpleExample.php
@@ -60,7 +60,7 @@ EOD;
 $handler=new MyHandler();
 
 // Instantiate the parser
-$parser=& new XML_HTMLSax();
+$parser= new XML_HTMLSax();
 
 // Register the handler with the parser
 $parser->set_object($handler);

--- a/inc/app/siteconnector/lib/Ext/PEAR/XML/SaxFilters/HTMLSaxParser.php
+++ b/inc/app/siteconnector/lib/Ext/PEAR/XML/SaxFilters/HTMLSaxParser.php
@@ -60,7 +60,7 @@ class XML_SaxFilters_HtmlSaxParser extends XML_SaxFilters_AbstractParser /* impl
     function XML_SaxFilters_HtmlSaxParser(& $reader)
     {
         parent::XML_SaxFilters_AbstractParser($reader);
-        $this->parser=& new XML_HTMLSax();
+        $this->parser= new XML_HTMLSax();
         $this->parser->set_object($this);
         $this->parser->set_element_handler('startElementHandler','endElementHandler');
         $this->parser->set_data_handler('characterDataHandler');

--- a/inc/app/siteconnector/lib/Ext/PEAR/XML/XML_HTMLSax.php
+++ b/inc/app/siteconnector/lib/Ext/PEAR/XML/XML_HTMLSax.php
@@ -158,15 +158,15 @@ class XML_HTMLSax_StateParser {
     */
     function XML_HTMLSax_StateParser (& $htmlsax) {
         $this->htmlsax = & $htmlsax;
-        $this->State[XML_HTMLSAX_STATE_START] =& new XML_HTMLSax_StartingState();
+        $this->State[XML_HTMLSAX_STATE_START] = new XML_HTMLSax_StartingState();
 
-        $this->State[XML_HTMLSAX_STATE_CLOSING_TAG] =& new XML_HTMLSax_ClosingTagState();
-        $this->State[XML_HTMLSAX_STATE_TAG] =& new XML_HTMLSax_TagState();
-        $this->State[XML_HTMLSAX_STATE_OPENING_TAG] =& new XML_HTMLSax_OpeningTagState();
+        $this->State[XML_HTMLSAX_STATE_CLOSING_TAG] = new XML_HTMLSax_ClosingTagState();
+        $this->State[XML_HTMLSAX_STATE_TAG] = new XML_HTMLSax_TagState();
+        $this->State[XML_HTMLSAX_STATE_OPENING_TAG] = new XML_HTMLSax_OpeningTagState();
 
-        $this->State[XML_HTMLSAX_STATE_PI] =& new XML_HTMLSax_PiState();
-        $this->State[XML_HTMLSAX_STATE_JASP] =& new XML_HTMLSax_JaspState();
-        $this->State[XML_HTMLSAX_STATE_ESCAPE] =& new XML_HTMLSax_EscapeState();
+        $this->State[XML_HTMLSAX_STATE_PI] = new XML_HTMLSax_PiState();
+        $this->State[XML_HTMLSAX_STATE_JASP] = new XML_HTMLSax_JaspState();
+        $this->State[XML_HTMLSAX_STATE_ESCAPE] = new XML_HTMLSax_EscapeState();
     }
 
     /**
@@ -241,14 +241,14 @@ class XML_HTMLSax_StateParser {
     */
     function parse($data) {
         if ($this->parser_options['XML_OPTION_TRIM_DATA_NODES']==1) {
-            $decorator =& new XML_HTMLSax_Trim(
+            $decorator = new XML_HTMLSax_Trim(
                 $this->handler_object_data,
                 $this->handler_method_data);
             $this->handler_object_data =& $decorator;
             $this->handler_method_data = 'trimData';
         }
         if ($this->parser_options['XML_OPTION_CASE_FOLDING']==1) {
-            $open_decor =& new XML_HTMLSax_CaseFolding(
+            $open_decor = new XML_HTMLSax_CaseFolding(
                 $this->handler_object_element,
                 $this->handler_method_opening,
                 $this->handler_method_closing);
@@ -257,28 +257,28 @@ class XML_HTMLSax_StateParser {
             $this->handler_method_closing ='foldClose';
         }
         if ($this->parser_options['XML_OPTION_LINEFEED_BREAK']==1) {
-            $decorator =& new XML_HTMLSax_Linefeed(
+            $decorator = new XML_HTMLSax_Linefeed(
                 $this->handler_object_data,
                 $this->handler_method_data);
             $this->handler_object_data =& $decorator;
             $this->handler_method_data = 'breakData';
         }
         if ($this->parser_options['XML_OPTION_TAB_BREAK']==1) {
-            $decorator =& new XML_HTMLSax_Tab(
+            $decorator = new XML_HTMLSax_Tab(
                 $this->handler_object_data,
                 $this->handler_method_data);
             $this->handler_object_data =& $decorator;
             $this->handler_method_data = 'breakData';
         }
         if ($this->parser_options['XML_OPTION_ENTITIES_UNPARSED']==1) {
-            $decorator =& new XML_HTMLSax_Entities_Unparsed(
+            $decorator = new XML_HTMLSax_Entities_Unparsed(
                 $this->handler_object_data,
                 $this->handler_method_data);
             $this->handler_object_data =& $decorator;
             $this->handler_method_data = 'breakData';
         }
         if ($this->parser_options['XML_OPTION_ENTITIES_PARSED']==1) {
-            $decorator =& new XML_HTMLSax_Entities_Parsed(
+            $decorator = new XML_HTMLSax_Entities_Parsed(
                 $this->handler_object_data,
                 $this->handler_method_data);
             $this->handler_object_data =& $decorator;
@@ -475,11 +475,11 @@ class XML_HTMLSax extends Pear {
     */
     function XML_HTMLSax() {
         if (version_compare(phpversion(), '4.3', 'ge')) {
-            $this->state_parser =& new XML_HTMLSax_StateParser_Gtet430($this);
+            $this->state_parser = new XML_HTMLSax_StateParser_Gtet430($this);
         } else {
-            $this->state_parser =& new XML_HTMLSax_StateParser_Lt430($this);
+            $this->state_parser = new XML_HTMLSax_StateParser_Lt430($this);
         }
-        $nullhandler =& new XML_HTMLSax_NullHandler();
+        $nullhandler = new XML_HTMLSax_NullHandler();
         $this->set_object($nullhandler);
         $this->set_element_handler('DoNothing', 'DoNothing');
         $this->set_data_handler('DoNothing');

--- a/inc/app/siteinvoice/lib/PEAR/HTTP/docs/download-progress.php
+++ b/inc/app/siteinvoice/lib/PEAR/HTTP/docs/download-progress.php
@@ -78,7 +78,7 @@ class HTTP_Request_DownloadListener extends HTTP_Request_Listener
                 } else {
                     $this->setTarget($this->_target);
                 }
-                $this->_bar =& new Console_ProgressBar(
+                $this->_bar = new Console_ProgressBar(
                     '* ' . $this->_target . ' %fraction% KB [%bar%] %percent%', '=>', '-', 
                     79, (isset($data['content-length'])? round($data['content-length'] / 1024): 100)
                 );
@@ -105,9 +105,9 @@ class HTTP_Request_DownloadListener extends HTTP_Request_Listener
 // to be able to see the progress bar
 $url = 'http://pear.php.net/get/HTML_QuickForm-stable';
 
-$req =& new HTTP_Request($url);
+$req = new HTTP_Request($url);
 
-$download =& new HTTP_Request_DownloadListener();
+$download = new HTTP_Request_DownloadListener();
 $req->attach($download);
 $req->sendRequest(false);
 ?>

--- a/inc/app/siteinvoice/lib/PEAR/PEAR.php
+++ b/inc/app/siteinvoice/lib/PEAR/PEAR.php
@@ -84,7 +84,7 @@ $GLOBALS['_PEAR_error_handler_stack']    = array();
  * destructor, use error_log(), syslog() or something similar.
  *
  * IMPORTANT! To use the emulated destructors you need to create the
- * objects by reference: $obj =& new PEAR_child;
+ * objects by reference: $obj = new PEAR_child;
  *
  * @category   pear
  * @package    PEAR

--- a/inc/app/siteinvoice/lib/PEAR/PEAR/Autoloader.php
+++ b/inc/app/siteinvoice/lib/PEAR/PEAR/Autoloader.php
@@ -149,7 +149,7 @@ class PEAR_Autoloader extends PEAR
             $include_file = preg_replace('/[^a-z0-9]/i', '_', $classname);
             include_once $include_file;
         }
-        $obj =& new $classname;
+        $obj = new $classname;
         $methods = get_class_methods($classname);
         foreach ($methods as $method) {
             // don't import priviate methods and constructors

--- a/inc/app/siteinvoice/lib/PEAR/PEAR/PackageFile/Generator/v1.php
+++ b/inc/app/siteinvoice/lib/PEAR/PEAR/PackageFile/Generator/v1.php
@@ -115,7 +115,7 @@ class PEAR_PackageFile_Generator_v1
         // }}}
         $packagexml = $this->toPackageFile($where, PEAR_VALIDATE_PACKAGING, 'package.xml', true);
         if ($packagexml) {
-            $tar =& new Archive_Tar($dest_package, $compress);
+            $tar = new Archive_Tar($dest_package, $compress);
             $tar->setErrorHandling(PEAR_ERROR_RETURN); // XXX Don't print errors
             // ----- Creates with the package.xml file
             $ok = $tar->createModify(array($packagexml), '', $where);

--- a/inc/app/siteinvoice/lib/PEAR/PEAR/PackageFile/Generator/v2.php
+++ b/inc/app/siteinvoice/lib/PEAR/PEAR/PackageFile/Generator/v2.php
@@ -258,7 +258,7 @@ http://pear.php.net/dtd/package-2.0.xsd',
         }
         $packagexml = $this->toPackageFile($where, PEAR_VALIDATE_PACKAGING, $name);
         if ($packagexml) {
-            $tar =& new Archive_Tar($dest_package, $compress);
+            $tar = new Archive_Tar($dest_package, $compress);
             $tar->setErrorHandling(PEAR_ERROR_RETURN); // XXX Don't print errors
             // ----- Creates with the package.xml file
             $ok = $tar->createModify(array($packagexml), '', $where);

--- a/inc/app/siteinvoice/lib/PEAR/Services/ExchangeRates/Common.php
+++ b/inc/app/siteinvoice/lib/PEAR/Services/ExchangeRates/Common.php
@@ -66,7 +66,7 @@ class Services_ExchangeRates_Common {
             include_once 'HTTP/Request.php';
             
             // HTTP_Request has moronic redirect "handling", turn that off (Alexey Borzov)
-            $req =& new HTTP_Request($url, array('allowRedirects' => false));
+            $req = new HTTP_Request($url, array('allowRedirects' => false));
             
             // if $cache->get($cacheID) found the file, but it was expired, 
             // $cache->_file will exist 

--- a/inc/app/siteinvoice/lib/PEAR/Services/ExchangeRates/Rates_NBI.php
+++ b/inc/app/siteinvoice/lib/PEAR/Services/ExchangeRates/Rates_NBI.php
@@ -13,7 +13,7 @@
 // | obtain it through the world-wide-web, please send a note to          |
 // | license@php.net so we can mail you a copy immediately.               |
 // +----------------------------------------------------------------------+
-// | Author: Simon Brüchner <powtac@gmx.de>			                      |
+// | Author: Simon BrÃ¼chner <powtac@gmx.de>			                      |
 // +----------------------------------------------------------------------+
 //
 // $Id: Rates_NBI.php,v 1.1 2005/07/02 21:12:31 lux Exp $
@@ -25,8 +25,8 @@
  *
  * @link 	http://www.bankisrael.gov.il/eng.shearim/
  *
- * @author 	Simon Brüchner <powtac@gmx.de>	
- * @copyright Copyright 2003 Simon Brüchner
+ * @author 	Simon BrÃ¼chner <powtac@gmx.de>	
+ * @copyright Copyright 2003 Simon BrÃ¼chner
  * @license http://www.php.net/license/2_02.txt PHP License 2.0
  * @package Services_ExchangeRates
  */

--- a/inc/app/siteinvoice/lib/PEAR/XML/Tree.php
+++ b/inc/app/siteinvoice/lib/PEAR/XML/Tree.php
@@ -13,7 +13,7 @@
 // | obtain it through the world-wide-web, please send a note to          |
 // | license@php.net so we can mail you a copy immediately.               |
 // +----------------------------------------------------------------------+
-// | Authors: Bernd Römer <berndr@bonn.edu>                               |
+// | Authors: Bernd RÃ¶mer <berndr@bonn.edu>                               |
 // |          Sebastian Bergmann <sb@sebastian-bergmann.de>               |
 // |          Tomas V.V.Cox <cox@idecnet.com>                             |
 // |          Michele Manzato <michele.manzato@verona.miz.it>             |
@@ -42,7 +42,7 @@ require_once 'XML/Tree/Node.php';
  *
  *    $tree->dump(true);
  *
- * @author  Bernd Römer <berndr@bonn.edu>
+ * @author  Bernd RÃ¶mer <berndr@bonn.edu>
  * @package XML
  * @version $Version$ - 1.0
  */

--- a/inc/app/siteinvoice/lib/PEAR/XML/Tree/Node.php
+++ b/inc/app/siteinvoice/lib/PEAR/XML/Tree/Node.php
@@ -12,9 +12,9 @@
 // | obtain it through the world-wide-web, please send a note to          |
 // | license@php.net so we can mail you a copy immediately.               |
 // +----------------------------------------------------------------------+
-// | Authors: Bernd Römer <berndr@bonn.edu>                               |
+// | Authors: Bernd RÃ¶mer <berndr@bonn.edu>                               |
 // |          Sebastian Bergmann <sb@sebastian-bergmann.de>               |
-// |          Christian Kühn <ck@chkuehn.de> (escape xml entities)        |
+// |          Christian KÃ¼hn <ck@chkuehn.de> (escape xml entities)        |
 // |          Michele Manzato <michele.manzato@verona.miz.it>             |
 // +----------------------------------------------------------------------+
 //
@@ -24,7 +24,7 @@
 /**
  * PEAR::XML_Tree_Node
  *
- * @author  Bernd Römer <berndr@bonn.edu>
+ * @author  Bernd RÃ¶mer <berndr@bonn.edu>
  * @package XML_Tree
  * @version 1.0  16-Aug-2001
  */
@@ -519,9 +519,9 @@ class XML_Tree_Node {
 
     function encodeXmlEntities($xml)
     {
-        $xml = str_replace(array('ü', 'Ü', 'ö',
-                                 'Ö', 'ä', 'Ä',
-                                 'ß', '<', '>',
+        $xml = str_replace(array('Ã¼', 'Ãœ', 'Ã¶',
+                                 'Ã–', 'Ã¤', 'Ã„',
+                                 'ÃŸ', '<', '>',
                                  '"', '\''
                                 ),
                            array('&#252;', '&#220;', '&#246;',

--- a/inc/app/sitellite/lib/geshi/contrib/aliased.php
+++ b/inc/app/sitellite/lib/geshi/contrib/aliased.php
@@ -41,7 +41,7 @@ if(!file_exists($path)) {
 $contents = file_get_contents($path);
 
 // Prepare GeSHi instance
-$geshi =& new GeSHi($contents, "PHP");
+$geshi = new GeSHi($contents, "PHP");
 $geshi->set_header_type(GESHI_HEADER_PRE);
 $geshi->enable_classes();
 $geshi->enable_line_numbers(GESHI_FANCY_LINE_NUMBERS, 10);

--- a/inc/app/sitellite/lib/geshi/geshi/erlang.php
+++ b/inc/app/sitellite/lib/geshi/geshi/erlang.php
@@ -355,7 +355,7 @@ $language_data = array(
         2 => ':'
         ),
     'REGEXPS' => array(
-        // Macro definitions
+        // Macro definitions
         0 => array(
             GESHI_SEARCH => '(-define\s*\()([a-zA-Z0-9_]+)(\(|,)',
             GESHI_REPLACE => '\2',
@@ -403,7 +403,7 @@ $language_data = array(
             GESHI_BEFORE => '\1',
             GESHI_AFTER => ''
             ),
-        // ASCII codes
+        // ASCII codes
         6 => '(\$[a-zA-Z0-9_])',
         // Records
         7 => array(

--- a/inc/app/sitesearch/boxes/stats/index/index.php
+++ b/inc/app/sitesearch/boxes/stats/index/index.php
@@ -42,6 +42,8 @@ $logger = new SiteSearchLogger;
 
 // indexing info
 
+$data = new stdClass;
+
 /*
 $data = $logger->getCurrentIndex ();
 if (! $data) {

--- a/inc/app/sitesearch/lib/Ext/fpdf/font/makefont/makefont.php
+++ b/inc/app/sitesearch/lib/Ext/fpdf/font/makefont/makefont.php
@@ -289,9 +289,9 @@ function CheckTTF($file)
 }
 
 /*******************************************************************************
-* $fontfile : chemin du fichier TTF (ou chaîne vide si pas d'incorporation)    *
+* $fontfile : chemin du fichier TTF (ou chaÃ®ne vide si pas d'incorporation)    *
 * $afmfile :  chemin du fichier AFM                                            *
-* $enc :      encodage (ou chaîne vide si la police est symbolique)            *
+* $enc :      encodage (ou chaÃ®ne vide si la police est symbolique)            *
 * $patch :    patch optionnel pour l'encodage                                  *
 * $type :     type de la police si $fontfile est vide                          *
 *******************************************************************************/

--- a/inc/app/sitewiki/forms/edit/index.php
+++ b/inc/app/sitewiki/forms/edit/index.php
@@ -75,7 +75,7 @@ class SitewikiEditForm extends MailForm {
 		}
 	}
 
-	function show () {
+	function show ($template = '') {
 		if (! $this->editable) {
 			return;
 		}

--- a/inc/app/sitewiki/lib/Ext/Text/Wiki.php
+++ b/inc/app/sitewiki/lib/Ext/Text/Wiki.php
@@ -1092,7 +1092,7 @@ class Text_Wiki {
             }
         }
         
-        $this->parseObj[$rule] =& new $class($this);
+        $this->parseObj[$rule] = new $class($this);
 
     }
     
@@ -1126,7 +1126,7 @@ class Text_Wiki {
             }
         }
         
-        $this->renderObj[$rule] =& new $class($this);
+        $this->renderObj[$rule] = new $class($this);
     }
     
     
@@ -1157,7 +1157,7 @@ class Text_Wiki {
             }
         }
         
-        $this->formatObj[$format] =& new $class($this);
+        $this->formatObj[$format] = new $class($this);
     }
     
     

--- a/inc/app/xed/boxes/editor/index.php
+++ b/inc/app/xed/boxes/editor/index.php
@@ -20,7 +20,7 @@ class WysiwygEditorForm extends MailForm {
 		$b->extra = 'onclick="return xed_window_cancel (this.form)"';
 	}
 
-	function show () {
+	function show ($template = '') {
 		echo '<script language="javascript" type="text/javascript">
 			function xed_window_submit (f) {
 				opener.document.forms[f.elements["form_name"].value].elements[f.elements["field_name"].value].value = xed_get_source ("body");

--- a/install/index.php
+++ b/install/index.php
@@ -128,7 +128,7 @@ thanks for your interest in Sitellite and welcome to the neighbourhood!</p>';
 			$data['body'] = '<p class="notice">Can\'t write to the Sitellite install directory</p>'
 				. '<h2>Solution:</h2>'
 				. '<ul><li>In your document root, execute the command `chmod 0777 install`</li></ul>';
-		} elseif (! extension_loaded ('mysql')) {
+		} elseif (! extension_loaded ('mysql') && ! extension_loaded ('mysqli')) {
 			// mysql check
 			$data['error'] = true;
 			$data['body'] = '<p class="notice">MySQL extension not found.</p>'

--- a/saf/lib/Database/Driver/MySQL.php
+++ b/saf/lib/Database/Driver/MySQL.php
@@ -109,6 +109,17 @@ class MySQL_Query extends Query {
 	 * 
 	 */
 	function MySQL_Query ($sql = '', &$conn, $cache = 0) {
+		if (version_compare (phpversion (), '7', '>=')) {
+			$this->_fetchModeFunctions = array (
+				DB_FETCHMODE_ASSOC		=> 'mysqli_fetch_array',
+				DB_FETCHMODE_OBJECT		=> 'mysqli_fetch_object',
+			);
+		} else {
+			$this->_fetchModeFunctions = array (
+				DB_FETCHMODE_ASSOC		=> 'mysql_fetch_array',
+				DB_FETCHMODE_OBJECT		=> 'mysql_fetch_object',
+			);
+		}
 		parent::Query ($sql, $conn, $cache);
 	}
 

--- a/saf/lib/Ext/nusoap/nusoap.php
+++ b/saf/lib/Ext/nusoap/nusoap.php
@@ -3496,7 +3496,7 @@ class soapclient extends nusoap_base  {
 			
 			// instantiate wsdl object and parse wsdl file
 			$this->debug('instantiating wsdl class with doc: '.$endpoint);
-			$this->wsdl =& new wsdl($this->wsdlFile);
+			$this->wsdl = new wsdl($this->wsdlFile);
 			$this->debug("wsdl debug: \n".$this->wsdl->debug_str);
 			// catch errors
 			if($errstr = $this->wsdl->getError()){

--- a/saf/lib/Ext/phpmailer/test_script/index.php
+++ b/saf/lib/Ext/phpmailer/test_script/index.php
@@ -105,7 +105,7 @@ if ( $_POST['submit'] == "Submit" ) {
   $mail->Subject  = $_POST['Subject'] . ' (PHPMailer test using ' . strtoupper($_POST['test_type']) . ')';
 
   require_once('../class.html2text.inc.php');
-  $h2t =& new html2text($body);
+  $h2t = new html2text($body);
   $mail->AltBody = $h2t->get_text();
   //$mail->AltBody    = "To view the message, please use an HTML compatible email viewer!"; // optional, comment out and test
   $mail->WordWrap   = 80; // set word wrap
@@ -253,7 +253,7 @@ echo '$mail->AddCC(\'' . $value . '\');<br />';
 $mail->Subject  = <?php echo $_POST['Subject']; ?> (PHPMailer test using <?php echo strtoupper($_POST['test_type']); ?>)
 
 require_once('../class.html2text.inc.php');
-$h2t =& new html2text($body);
+$h2t = new html2text($body);
 $mail->AltBody = $h2t->get_text();
 $mail->WordWrap   = 80; // set word wrap
 

--- a/saf/lib/Ext/phpsniff/index.php
+++ b/saf/lib/Ext/phpsniff/index.php
@@ -36,13 +36,13 @@ if(!isset($GET_VARS['cc'])) $GET_VARS['cc'] = '';
 if(!isset($GET_VARS['dl'])) $GET_VARS['dl'] = '';
 if(!isset($GET_VARS['am'])) $GET_VARS['am'] = '';
 
-$timer =& new phpTimer();
+$timer = new phpTimer();
 $timer->start('main');
 $timer->start('client1');
 $sniffer_settings = array('check_cookies'=>$GET_VARS['cc'],
                           'default_language'=>$GET_VARS['dl'],
                           'allow_masquerading'=>$GET_VARS['am']);
-$client =& new phpSniff($GET_VARS['UA'],$sniffer_settings);
+$client = new phpSniff($GET_VARS['UA'],$sniffer_settings);
 
 $timer->stop('client1');
 

--- a/saf/lib/File/Directory.php
+++ b/saf/lib/File/Directory.php
@@ -152,7 +152,7 @@ class Dir extends Directory {
 			return array ();
 		}
 		$this->_ls = array ();
-		while ($file = $this->dir->read ()) {
+		while ($file = $this->dir->read ($this->handle)) {
 			array_push ($this->_ls, $file);
 		}
 		$this->_sort ($sorting_method);
@@ -175,8 +175,8 @@ class Dir extends Directory {
 	 * @return	string
 	 * 
 	 */
-	function read () {
-		return $this->dir->read ();
+	function read ($dir_handle = NULL) {
+		return $this->dir->read ($dir_handle);
 	}
 
 	/**
@@ -185,8 +185,8 @@ class Dir extends Directory {
 	 * @access	public
 	 * 
 	 */
-	function rewind () {
-		return $this->dir->rewind ();
+	function rewind ($dir_handle = NULL) {
+		return $this->dir->rewind ($dir_handle);
 	}
 
 	/**
@@ -195,8 +195,8 @@ class Dir extends Directory {
 	 * @access	public
 	 * 
 	 */
-	function close () {
-		return $this->dir->close ();
+	function close ($dir_handle = NULL) {
+		return $this->dir->close ($dir_handle);
 	}
 
 	/**
@@ -308,7 +308,7 @@ class Dir extends Directory {
 				}
 			}
 		}
-		$dir->close ();
+		$dir->close ($dir->handle);
 		return $res;
 	}
 
@@ -347,7 +347,7 @@ class Dir extends Directory {
 				}
 			}
 		}
-		$dir->close ();
+		$dir->close ($dir->handle);
 		return $res;
 	}
 

--- a/saf/lib/Functions7.php
+++ b/saf/lib/Functions7.php
@@ -1,0 +1,353 @@
+<?php
+//
+// +----------------------------------------------------------------------+
+// | Sitellite Content Management System                                  |
+// +----------------------------------------------------------------------+
+// | Copyright (c) 2010-2018 Sitellite.org Community                           |
+// +----------------------------------------------------------------------+
+// | This software is released under the GNU GPL License.                 |
+// | Please see the accompanying file docs/LICENSE for licensing details. |
+// |                                                                      |
+// | You should have received a copy of the GNU GPL License               |
+// | along with this program; if not, visit www.sitellite.org.            |
+// | The license text is also available at the following web site         |
+// | address: <http://www.sitellite.org/index/license                     |
+// +----------------------------------------------------------------------+
+// | Authors: Oleg Ivanchenko <oiv@ry.ru>                       |
+// +----------------------------------------------------------------------+
+//
+
+/**
+ * This file keeps functions missing from PHP7 but still used by
+ *  Sitellite Application Framework.
+ *
+ * @package Functions7
+ * @access public
+ * @since 07.03.2018
+ * @version 1.0.0 08.03.2018
+ * @author Oleg Ivanchenko <oiv@ry.ru>
+ * @copyright Copyright (C) 2018
+ */
+
+/**
+ * As for replacement of mysql_* by mysqli_* functions:
+ *  mysqli_result does not exists in PHP 7.*.
+ *
+ * @param mysqli_result $result
+ * @param int $row
+ * @param int $col
+ * @return boolean|string
+ */
+function mysqli_result ($result, $row = 0, $col = 0) {
+	$numrows = mysqli_num_rows ($result);
+	if ($numrows && $row <= ($numrows - 1) && $row >= 0) {
+		mysqli_data_seek ($result, $row);
+		$resrow = (is_numeric ($col)) ? mysqli_fetch_row ($result) : mysqli_fetch_assoc ($result);
+		if (isset ($resrow[$col])) {
+			return $resrow[$col];
+		}
+	}
+	return false;
+}
+
+/**
+ * As for replacement of mysql_* by mysqli_* functions:
+ *  mysqli_field_name does not exists in PHP 7.*.
+ *
+ * @param mysqli_result $result
+ * @param int $field_offset
+ * @return string
+ */
+function mysqli_field_name ($result, $field_offset) {
+
+	$properties = mysqli_fetch_field_direct ($result, $field_offset);
+	return is_object ($properties) ? $properties->name : null;
+}
+
+if (! function_exists ('mysql_connect')) {
+
+	/**
+   * As for replacement of mysql_* by mysqli_* functions:
+   *  mysql_connect does not exists in PHP 7.*.
+	 *
+	 * @param string $host
+	 * @param string $user
+	 * @param string $password
+	 * @param  bool $new_link  [optional]
+	 * @param int $client_flags [optional]
+	 * @return resource
+	 */
+	function mysql_connect ($host, $user, $password, $new_link = FALSE, int $client_flags = 0) {
+
+		list ($db_host, $db_port) = explode (':', $host);
+		return mysqli_connect ($db_host, $user, $password, '', $db_port);
+	}
+}
+
+if (! function_exists ('mysql_pconnect')) {
+
+	/**
+	 * As for replacement of mysql_* by mysqli_* functions:
+	 *  mysql_pconnect does not exists in PHP 7.*.
+	 *
+	 * @param string $host
+	 * @param string $user
+	 * @param string $password
+	 * @param  bool $new_link  [optional]
+	 * @param int $client_flags [optional]
+	 * @return resource
+	 */
+	function mysql_pconnect ($host, $user, $password, $new_link = FALSE, int $client_flags = 0) {
+
+		list ($db_host, $db_port) = explode (':', $host);
+		return mysqli_connect ('p:' . $db_host, $user, $password, '', $db_port);
+	}
+}
+
+if (! function_exists ('mysql_field_name')) {
+
+	/**
+	 * As for replacement of mysql_* by mysqli_* functions:
+	 *  mysql_field_name does not exists in PHP 7.*.
+	 *
+	 * @param mysqli_result $result
+	 * @param int $field_offset
+	 * @return string
+	 */
+	function mysql_field_name ($result, $field_offset) {
+
+		$properties = mysqli_fetch_field_direct ($result, $field_offset);
+		return is_object ($properties) ? $properties->name : null;
+	}
+}
+
+if (! function_exists ('mysql_result')) {
+
+	/**
+	 * As for replacement of mysql_* by mysqli_* functions:
+	 *  mysql_result does not exists in PHP 7.*.
+	 *
+	 * @param mysqli_result $result
+	 * @param int $row
+	 * @param mixed $col [optional]
+	 * @return boolean|string
+	 */
+	function mysql_result ($result, $row, $col = 0) {
+
+		$numrows = mysqli_num_rows ($result);
+		if ($numrows && $row <= ($numrows - 1) && $row >= 0) {
+			mysqli_data_seek ($result, $row);
+			$resrow = (is_numeric ($col)) ? mysqli_fetch_row ($result) : mysqli_fetch_assoc ($result);
+			if (isset ($resrow[$col])) {
+				return $resrow[$col];
+			}
+		}
+		return false;
+	}
+}
+
+if (! function_exists ('mysql_select_db')) {
+
+	/**
+	 * As for replacement of mysql_* by mysqli_* functions:
+	 *  mysql_select_db does not exists in PHP 7.*.
+	 *
+	 * Selects the default database for database queries
+	 *
+	 * @param string $database_name
+	 * @param resource $link_identifier [optional]
+	 * @return bool
+	 */
+	function mysql_select_db ($database_name, $link_identifier =  NULL) {
+
+		return mysqli_select_db ($link_identifier , $database_name);
+	}
+}
+
+if (! function_exists ('mysql_fetch_array')) {
+
+	/**
+	 * As for replacement of mysql_* by mysqli_* functions:
+	 *  mysql_fetch_array does not exists in PHP 7.*.
+	 *
+	 * Fetch a result row as an associative, a numeric array, or both
+	 *
+	 * @param mysqli_result $result
+	 * @param int $result_type [optional]
+	 * @return mixed an array of strings that corresponds to the fetched row or <b>NULL</b> if there
+	 *   are no more rows in resultset.
+	 */
+	function mysql_fetch_array ($result, $result_type = MYSQL_BOTH) {
+
+		return mysqli_fetch_array ($result, $result_type);
+	}
+}
+
+if (! function_exists ('mysql_fetch_object')) {
+
+	/**
+	 * As for replacement of mysql_* by mysqli_* functions:
+	 *  mysql_fetch_object does not exists in PHP 7.*.
+	 *
+	 * Returns the current row of a result set as an object
+	 *
+	 * @param mysqli_result $result
+	 * @param string $class_name [optional]
+	 * @param array $params [optional]
+	 * @return object an object with string properties that corresponds to the fetched
+   *   row or <b>NULL</b> if there are no more rows in resultset.
+	 */
+	function mysql_fetch_object ($result, $class_name, $params = null) {
+
+		return mysqli_fetch_object ($result, $class_name, $params);
+	}
+}
+
+if (! function_exists ('mysql_query')) {
+
+	/**
+	 * As for replacement of mysql_* by mysqli_* functions:
+	 *  mysql_query does not exists in PHP 7.*.
+	 *
+	 * Performs a query on the database
+	 *
+	 * @param string $query
+	 * @param resource $link_identifier [optional]
+	 * @return mixed <b>FALSE</b> on failure. For successful SELECT, SHOW, DESCRIBE or
+   * EXPLAIN queries <b>mysqli_query</b> will return
+   * a <b>mysqli_result</b> object. For other successful queries <b>mysqli_query</b> will
+   * return <b>TRUE</b>.
+	 */
+	function mysql_query ($query, $link_identifier = NULL) {
+
+		return mysqli_query ($link_identifier, $query);
+	}
+}
+
+if (! function_exists ('mysql_num_rows')) {
+
+	/**
+	 * As for replacement of mysql_* by mysqli_* functions:
+	 *  mysql_num_rows does not exists in PHP 7.*.
+	 *
+	 * Gets the number of rows in a result
+	 *
+	 * @param mysqli_result $result
+   * @return int number of rows in the result set.
+   *  If the number of rows is greater than <b>PHP_INT_MAX</b>, the number
+   *  will be returned as a string.
+	 */
+	function mysql_num_rows ($result) {
+
+		return mysqli_num_rows ($result);
+	}
+}
+
+if (! function_exists ('mysql_insert_id')) {
+
+	/**
+	 * As for replacement of mysql_* by mysqli_* functions:
+	 *  mysql_insert_id does not exists in PHP 7.*.
+	 *
+	 * Returns the auto generated id used in the last query
+	 *
+	 * @param resource $link_identifier [optional]
+   * @return mixed The value of the AUTO_INCREMENT field that was updated
+   * by the previous query. Returns zero if there was no previous query on the
+   * connection or if the query did not update an AUTO_INCREMENT
+   * value.
+   * If the number is greater than maximal int value, <b>mysqli_insert_id</b>
+   * will return a string.
+	 */
+	function mysql_insert_id ($link_identifier = NULL) {
+
+		return mysqli_insert_id ($link_identifier);
+	}
+}
+
+if (! function_exists ('mysql_free_result')) {
+
+	/**
+	 * As for replacement of mysql_* by mysqli_* functions:
+	 *  mysql_free_result does not exists in PHP 7.*.
+	 *
+	 * Frees the memory associated with a result
+	 *
+	 * @param mysqli_result $result
+   * @return void No value is returned.
+	 */
+	function mysql_free_result ($result) {
+
+		mysqli_free_result ($result);
+	}
+}
+
+if (! function_exists ('mysql_errno')) {
+
+	/**
+	 * As for replacement of mysql_* by mysqli_* functions:
+	 *  mysql_errno does not exists in PHP 7.*.
+	 *
+	 * Returns the error code for the most recent function call
+	 *
+	 * @param resource $link_identifier [optional]
+   * @return int An error code value for the last call, if it failed. zero means no error
+   * occurred.
+	 */
+	function mysql_errno ($link_identifier = NULL) {
+
+		return mysqli_errno ($link_identifier);
+	}
+}
+
+if (! function_exists ('mysql_error')) {
+
+	/**
+	 * As for replacement of mysql_* by mysqli_* functions:
+	 *  mysql_error does not exists in PHP 7.*.
+	 *
+	 * Returns a string description of the last error
+	 *
+	 * @param resource $link_identifier [optional]
+   * @return string A string that describes the error. An empty string if no error occurred.
+	 */
+	function mysql_error ($link_identifier = NULL) {
+
+		return mysqli_error ($link_identifier);
+	}
+}
+
+if (! function_exists ('mysql_close')) {
+
+	/**
+	 * As for replacement of mysql_* by mysqli_* functions:
+	 *  mysql_close does not exists in PHP 7.*.
+	 *
+	 * Closes a previously opened database connection
+	 *
+	 * @param resource $link_identifier [optional]
+   * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
+	 */
+	function mysql_close ($link_identifier = NULL) {
+
+		return mysqli_close ($link_identifier);
+	}
+}
+
+if (! function_exists ('mysql_real_escape_string')) {
+
+	/**
+	 * As for replacement of mysql_* by mysqli_* functions:
+	 *  mysql_real_escape_string does not exists in PHP 7.*.
+	 *
+	 * Escapes special characters in a string for use in an SQL statement, taking into account the current charset of the connection
+	 *
+	 * @param string $unescaped_string
+	 * @param resource $link_identifier [optional]
+   * @return string an escaped string.
+	 */
+	function mysql_real_escape_string ($unescaped_string, $link_identifier = NULL) {
+
+		return mysqli_real_escape_string ($link_identifier, $unescaped_string);
+	}
+}

--- a/saf/lib/Functions7.php
+++ b/saf/lib/Functions7.php
@@ -24,7 +24,7 @@
  * @package Functions7
  * @access public
  * @since 07.03.2018
- * @version 1.0.0 08.03.2018
+ * @version 1.0.1 02.05.2018
  * @author Oleg Ivanchenko <oiv@ry.ru>
  * @copyright Copyright (C) 2018
  */
@@ -349,5 +349,19 @@ if (! function_exists ('mysql_real_escape_string')) {
 	function mysql_real_escape_string ($unescaped_string, $link_identifier = NULL) {
 
 		return mysqli_real_escape_string ($link_identifier, $unescaped_string);
+	}
+}
+
+if (! function_exists ('set_magic_quotes_runtime')) {
+
+	/**
+	 * This function was DEPRECATED in PHP 5.3.0, and REMOVED as of PHP 7.0.0.
+	 *
+	 * @param bool $new_setting
+   * @return bool
+	 */
+	function set_magic_quotes_runtime ($new_setting) {
+
+		return FALSE;
 	}
 }

--- a/saf/lib/GUI/Menu.php
+++ b/saf/lib/GUI/Menu.php
@@ -486,7 +486,7 @@ class Menu {
 	 13-1-2012
 	 */
 	function &addParent ($id, $title, $ref = '', $sect = '', $template = '') {
-		$this->{'items_' . $id} =& new MenuItem ($id, $title);
+		$this->{'items_' . $id} = new MenuItem ($id, $title);
 		
 		
 		if (empty ($ref)) {
@@ -517,7 +517,7 @@ class Menu {
 	 * 
 	 */
 	function &addItem ($id, $title, $ref = '', $sect = '', $template = '') {
-		$this->{'items_' . $id} =& new MenuItem ($id, $title);
+		$this->{'items_' . $id} = new MenuItem ($id, $title);
 		if (empty ($ref)) {
 			$this->tree[] =& $this->{'items_' . $id};
 		} else {

--- a/saf/lib/PEAR/Cache/DB.php
+++ b/saf/lib/PEAR/Cache/DB.php
@@ -338,7 +338,7 @@ class Cache_DB_Result {
             case DB_FETCHMODE_ASSOC: {
                 if (isset($return_object)) {
                     $class  =  $this->fetchmode_object_class;
-                    $object =& new $class($row);
+                    $object = new $class($row);
 
                     return $object;
                 } else {

--- a/saf/lib/PEAR/DB/DB-1.4.0/DB-1.4.0/DB.php
+++ b/saf/lib/PEAR/DB/DB-1.4.0/DB-1.4.0/DB.php
@@ -233,7 +233,7 @@ class DB
                                     null, null, null, 'DB_Error', true);
         }
 
-        @$obj =& new $classname;
+        @$obj = new $classname;
 
         return $obj;
     }
@@ -285,7 +285,7 @@ class DB
                                     'DB_Error', true);
         }
 
-        @$obj =& new $classname;
+        @$obj = new $classname;
 
         if (is_array($options)) {
             foreach ($options as $option => $value) {
@@ -751,7 +751,7 @@ class DB_result
             if ($object_class == 'stdClass') {
                 $ret = (object) $arr;
             } else {
-                $ret =& new $object_class($arr);
+                $ret = new $object_class($arr);
             }
             return $ret;
         }

--- a/saf/lib/PEAR/DB/NestedSet.php
+++ b/saf/lib/PEAR/DB/NestedSet.php
@@ -745,7 +745,7 @@ class DB_NestedSet extends PEAR {
 				$nodes[$node_id] = $row;
 			} else {
 				// Create an instance of the node container
-				$nodes[$node_id] =& new NestedSet_Node($row);
+				$nodes[$node_id] = new NestedSet_Node($row);
 			}
 			
 		}

--- a/saf/lib/PEAR/DB/NestedSet/TreeMenu.php
+++ b/saf/lib/PEAR/DB/NestedSet/TreeMenu.php
@@ -76,9 +76,9 @@ class DB_NestedSet_TreeMenu extends DB_NestedSet_Output {
         // so a root node will always be first, and sub children will always
         // be after them.
         if (!isset($params['treeMenu'])) {
-            $treeMenu =& new HTML_TreeMenu();
+            $treeMenu = new HTML_TreeMenu();
         } else {
-            $treeMenu =& $params['treeMenu'];
+            $treeMenu = $params['treeMenu'];
         }
 
         // always start at level 1
@@ -143,7 +143,7 @@ class DB_NestedSet_TreeMenu extends DB_NestedSet_Output {
      */		    
     function printTree() {
 		$options = $this->_getOptions('printTree');
-    	$tree =& new HTML_TreeMenu_DHTML($this->_structTreeMenu, $options);
+    	$tree = new HTML_TreeMenu_DHTML($this->_structTreeMenu, $options);
     	$tree->printMenu();
     }
 
@@ -157,7 +157,7 @@ class DB_NestedSet_TreeMenu extends DB_NestedSet_Output {
      */			    
     function printListbox() {
     	$options = $this->_getOptions('printListbox');
-    	$listBox  =& new HTML_TreeMenu_Listbox($this->_structTreeMenu, $options);
+    	$listBox  = new HTML_TreeMenu_Listbox($this->_structTreeMenu, $options);
     	$listBox->printMenu();
     }
 

--- a/saf/lib/PEAR/PEAR/Autoloader.php
+++ b/saf/lib/PEAR/PEAR/Autoloader.php
@@ -38,7 +38,7 @@ require_once "PEAR.php";
  * methods, an instance of each class providing separated methods is
  * stored and called every time the aggregated method is called.
  *
- * @author Stig Sæther Bakken <ssb@fast.no>
+ * @author Stig Sï¿½ther Bakken <ssb@fast.no>
  */
 class PEAR_Autoloader extends PEAR
 {
@@ -121,7 +121,7 @@ class PEAR_Autoloader extends PEAR
             $include_file = preg_replace('/[^a-z0-9]/i', '_', $classname);
             include_once $include_file;
         }
-        $obj =& new $classname;
+        $obj = new $classname;
         $methods = get_class_methods($classname);
         foreach ($methods as $method) {
             // don't import priviate methods and constructors

--- a/saf/lib/PEAR/PEAR/Command/Package.php
+++ b/saf/lib/PEAR/PEAR/Command/Package.php
@@ -252,7 +252,7 @@ Wrote: /usr/src/redhat/RPMS/i386/PEAR::Net_Socket-1.0-1.i386.rpm
         include_once 'PEAR/Packager.php';
         $pkginfofile = isset($params[0]) ? $params[0] : 'package.xml';
         ob_start();
-        $packager =& new PEAR_Packager($this->config->get('php_dir'),
+        $packager = new PEAR_Packager($this->config->get('php_dir'),
                                        $this->config->get('ext_dir'),
                                        $this->config->get('doc_dir'));
         $packager->debug = $this->config->get('verbose');

--- a/saf/lib/PEAR/PEAR/Installer.php
+++ b/saf/lib/PEAR/PEAR/Installer.php
@@ -796,7 +796,7 @@ class PEAR_Installer extends PEAR_Common
             }
             $n = count($failed_deps);
             if ($n > 0) {
-                $depinstaller =& new PEAR_Installer($this->ui);
+                $depinstaller = new PEAR_Installer($this->ui);
                 $to_install = array();
                 for ($i = 0; $i < $n; $i++) {
                     if (isset($failed_deps[$i]['type'])) {

--- a/saf/lib/PEAR/PEAR/Packager.php
+++ b/saf/lib/PEAR/PEAR/Packager.php
@@ -117,7 +117,7 @@ class PEAR_Packager extends PEAR_Common
         // TAR the Package -------------------------------------------
         $ext = $compress ? '.tgz' : '.tar';
         $dest_package = $oldcwd . DIRECTORY_SEPARATOR . $pkgver . $ext;
-        $tar =& new Archive_Tar($dest_package, $compress);
+        $tar = new Archive_Tar($dest_package, $compress);
         $tar->setErrorHandling(PEAR_ERROR_RETURN); // XXX Don't print errors
         // ----- Creates with the package.xml file
         $ok = $tar->createModify($newpkgfile, '', $tmpdir);

--- a/saf/lib/PEAR/PHPUnit/GUI/SetupDecorator.php
+++ b/saf/lib/PEAR/PHPUnit/GUI/SetupDecorator.php
@@ -83,7 +83,7 @@ class PHPUnit_GUI_SetupDecorator
         foreach ($files as $className=>$aFile) {
             include_once($aFile);
             if (class_exists($className)) {
-                $suites[] =& new PHPUnit_TestSuite($className);
+                $suites[] = new PHPUnit_TestSuite($className);
             } else {
                 trigger_error("$className could not be found in $dir$aFile!");
             }

--- a/saf/lib/PEAR/Structures/Tree/Memory.php
+++ b/saf/lib/PEAR/Structures/Tree/Memory.php
@@ -167,7 +167,7 @@ class Tree_Memory extends Tree_Common
         require_once("Tree/Memory/$type.php");
 
         $className = 'Tree_Memory_'.$type;
-        $this->dataSourceClass =& new $className( $dsn , $options );
+        $this->dataSourceClass = new $className( $dsn , $options );
         // copy the options to be able to get them via getOption(s)
 //FIXXME this is not really cool, maybe overwrite the *Option* methods!!!
         if( isset($this->dataSourceClass->options) )

--- a/saf/lib/PEAR/XML/XML_HTMLSax.php
+++ b/saf/lib/PEAR/XML/XML_HTMLSax.php
@@ -158,20 +158,20 @@ class XML_HTMLSax_StateParser {
     */
     function XML_HTMLSax_StateParser (& $htmlsax) {
         $this->htmlsax = & $htmlsax;
-        $this->State[XML_HTMLSAX_STATE_START] =& new XML_HTMLSax_StartingState();
+        $this->State[XML_HTMLSAX_STATE_START] = new XML_HTMLSax_StartingState();
 
-        $this->State[XML_HTMLSAX_STATE_CLOSING_TAG] =& new XML_HTMLSax_ClosingTagState();
-        $this->State[XML_HTMLSAX_STATE_TAG] =& new XML_HTMLSax_TagState();
-        $this->State[XML_HTMLSAX_STATE_OPENING_TAG] =& new XML_HTMLSax_OpeningTagState();
+        $this->State[XML_HTMLSAX_STATE_CLOSING_TAG] = new XML_HTMLSax_ClosingTagState();
+        $this->State[XML_HTMLSAX_STATE_TAG] = new XML_HTMLSax_TagState();
+        $this->State[XML_HTMLSAX_STATE_OPENING_TAG] = new XML_HTMLSax_OpeningTagState();
 
         $this->State[XML_HTMLSAX_STATE_ATTRIBUTE] =
             & new XML_HTMLSax_AttributeStartState();
         $this->State[XML_HTMLSAX_STATE_ATTRIBUTE]->attribute_handler =
             & $this->State[XML_HTMLSAX_STATE_OPENING_TAG];
 
-        $this->State[XML_HTMLSAX_STATE_PI] =& new XML_HTMLSax_PiState();
-        $this->State[XML_HTMLSAX_STATE_JASP] =& new XML_HTMLSax_JaspState();
-        $this->State[XML_HTMLSAX_STATE_ESCAPE] =& new XML_HTMLSax_EscapeState();
+        $this->State[XML_HTMLSAX_STATE_PI] = new XML_HTMLSax_PiState();
+        $this->State[XML_HTMLSAX_STATE_JASP] = new XML_HTMLSax_JaspState();
+        $this->State[XML_HTMLSAX_STATE_ESCAPE] = new XML_HTMLSax_EscapeState();
     }
 
     /**
@@ -246,14 +246,14 @@ class XML_HTMLSax_StateParser {
     */
     function parse($data) {
         if ($this->parser_options['XML_OPTION_TRIM_DATA_NODES']==1) {
-            $decorator =& new XML_HTMLSax_Trim(
+            $decorator = new XML_HTMLSax_Trim(
                 $this->handler_object_data,
                 $this->handler_method_data);
             $this->handler_object_data =& $decorator;
             $this->handler_method_data = 'trimData';
         }
         if ($this->parser_options['XML_OPTION_CASE_FOLDING']==1) {
-            $open_decor =& new XML_HTMLSax_CaseFolding(
+            $open_decor = new XML_HTMLSax_CaseFolding(
                 $this->handler_object_element,
                 $this->handler_method_opening,
                 $this->handler_method_closing);
@@ -262,14 +262,14 @@ class XML_HTMLSax_StateParser {
             $this->handler_method_closing ='foldClose';
         }
         if ($this->parser_options['XML_OPTION_LINEFEED_BREAK']==1) {
-            $decorator =& new XML_HTMLSax_Linefeed(
+            $decorator = new XML_HTMLSax_Linefeed(
                 $this->handler_object_data,
                 $this->handler_method_data);
             $this->handler_object_data =& $decorator;
             $this->handler_method_data = 'breakData';
         }
         if ($this->parser_options['XML_OPTION_TAB_BREAK']==1) {
-            $decorator =& new XML_HTMLSax_Tab(
+            $decorator = new XML_HTMLSax_Tab(
                 $this->handler_object_data,
                 $this->handler_method_data);
             $this->handler_object_data =& $decorator;
@@ -355,7 +355,7 @@ class XML_HTMLSax_StateParser_Lt430 extends XML_HTMLSax_StateParser {
     */
     function parse($data) {
         if ($this->parser_options['XML_OPTION_ENTITIES_UNPARSED']==1) {
-            $decorator =& new XML_HTMLSax_Entities_Unparsed(
+            $decorator = new XML_HTMLSax_Entities_Unparsed(
                 $this->handler_object_data,
                 $this->handler_method_data);
             $this->handler_object_data =& $decorator;
@@ -421,14 +421,14 @@ class XML_HTMLSax_StateParser_Gtet430 extends XML_HTMLSax_StateParser {
     */
     function parse($data) {
         if ($this->parser_options['XML_OPTION_ENTITIES_PARSED']==1) {
-            $decorator =& new XML_HTMLSax_Entities_Parsed(
+            $decorator = new XML_HTMLSax_Entities_Parsed(
                 $this->handler_object_data,
                 $this->handler_method_data);
             $this->handler_object_data =& $decorator;
             $this->handler_method_data = 'breakData';
         }
         if ($this->parser_options['XML_OPTION_ENTITIES_UNPARSED']==1) {
-            $decorator =& new XML_HTMLSax_Entities_Unparsed(
+            $decorator = new XML_HTMLSax_Entities_Unparsed(
                 $this->handler_object_data,
                 $this->handler_method_data);
             $this->handler_object_data =& $decorator;
@@ -484,11 +484,11 @@ class XML_HTMLSax extends Pear {
     */
     function XML_HTMLSax() {
         if (strcmp('4.3.0', phpversion()) <= 0) {
-            $this->state_parser =& new XML_HTMLSax_StateParser_Gtet430($this);
+            $this->state_parser = new XML_HTMLSax_StateParser_Gtet430($this);
         } else {
-            $this->state_parser =& new XML_HTMLSax_StateParser_Lt430($this);
+            $this->state_parser = new XML_HTMLSax_StateParser_Lt430($this);
         }
-        $nullhandler =& new XML_HTMLSax_NullHandler();
+        $nullhandler = new XML_HTMLSax_NullHandler();
         $this->set_object($nullhandler);
         $this->set_element_handler('DoNothing', 'DoNothing');
         $this->set_data_handler('DoNothing');

--- a/saf/lib/PEAR/XML/docs/examples/ExpatvsHtmlSax.php
+++ b/saf/lib/PEAR/XML/docs/examples/ExpatvsHtmlSax.php
@@ -20,7 +20,7 @@ class MyHandler {
     function closeHandler(& $parser,$name) {}
     function dataHandler(& $parser,$data) {}
 }
-$handler=& new MyHandler();
+$handler= new MyHandler();
 
 
 $parser = xml_parser_create();
@@ -36,7 +36,7 @@ $end = getmicrotime();
 echo ( "Expat took:\t\t".(getmicrotime()-$start)."<br />" );
 
 $start = getmicrotime();
-$parser =& new XML_HTMLSax();
+$parser = new XML_HTMLSax();
 $parser->set_object($handler);
 $parser->set_element_handler('openHandler','closeHandler');
 $parser->set_data_handler('dataHandler');

--- a/saf/lib/PEAR/XML/docs/examples/HTMLtoXHTML.php
+++ b/saf/lib/PEAR/XML/docs/examples/HTMLtoXHTML.php
@@ -97,10 +97,10 @@ class HTMLtoXHTMLHandler {
 $doc=file_get_contents('example.html');
 
 // Instantiate the handler
-$handler=& new HTMLtoXHTMLHandler();
+$handler= new HTMLtoXHTMLHandler();
 
 // Instantiate the parser
-$parser=& new XML_HTMLSax();
+$parser= new XML_HTMLSax();
 
 // Register the handler with the parser
 $parser->set_object($handler);

--- a/saf/lib/PEAR/XML/docs/examples/SimpleExample.php
+++ b/saf/lib/PEAR/XML/docs/examples/SimpleExample.php
@@ -60,7 +60,7 @@ EOD;
 $handler=new MyHandler();
 
 // Instantiate the parser
-$parser=& new XML_HTMLSax();
+$parser= new XML_HTMLSax();
 
 // Register the handler with the parser
 $parser->set_object($handler);

--- a/saf/lib/Session/Source/Source.php
+++ b/saf/lib/Session/Source/Source.php
@@ -287,7 +287,7 @@ class SessionSource {
 	 * @access  public
 	 *
 	 */
-	function getList ($offset, $limit, $order, $ascdesc, $role, $team, $name) {
+	function getList ($offset, $limit, $order, $ascdesc, $role, $team, $name, $disabled, $public, $teams) {
 	}
 }
 

--- a/saf/minimal.php
+++ b/saf/minimal.php
@@ -88,6 +88,11 @@ $loader = new Loader (array (
 // used occasionally within SAF packages.
 $loader->import ('saf.Functions');
 
+// PHP7 missing functions
+if (version_compare (phpversion (), '7', '>=')) {
+	$loader->import ('saf.Functions7');
+}
+
 // For those pear and ext packages that use the include_path:
 if (strtoupper (substr (PHP_OS, 0, 3)) === 'WIN') {
 	$join = ';';


### PR DESCRIPTION
This update is targeted on making Sitellite CMS PHP 7 compatible.

The following issues were fixed:

1) mysql_* missing PHP 7 functions.
2) preg_replace(): The /e modifier is no longer supported.
3) unexpected 'new' (T_NEW): `=& new` changed to `= new`.

There are also some minor updates:

1) Non initialized variables PHP warnings fixed.
2) PHP7 MySQL extension (mysqli) option added for installation script.
3) Blog form field property fixed.
4) Several files UTP-8 encoding fixed.
5) Due to missing applications list, box cms/admintools/uninstalled is ignored.